### PR TITLE
chore: rename module to ilp-routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# five-bells-routing
+# ilp-routing
 
 > ILP routing table implementation
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "five-bells-routing",
+  "name": "ilp-routing",
   "version": "4.0.0",
   "description": "ILP routing layer utilities",
   "main": "index.js",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/interledger/five-bells-routing.git"
+    "url": "https://github.com/interledger/js-ilp-routing.git"
   },
   "keywords": [
     "ilp",
@@ -46,9 +46,9 @@
   "author": "Interledger Team <info@interledger.org>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/interledger/five-bells-routing/issues"
+    "url": "https://github.com/interledger/js-ilp-routing/issues"
   },
-  "homepage": "https://github.com/interledger/five-bells-routing",
+  "homepage": "https://github.com/interledger/js-ilp-routing",
   "config": {
     "ghooks": {
       "commit-msg": "validate-commit-msg"

--- a/src/lib/routing-table.js
+++ b/src/lib/routing-table.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const PrefixMap = require('./prefix-map')
-const debug = require('debug')('five-bells-routing:routing-table')
+const debug = require('debug')('ilp-routing:routing-table')
 
 class RoutingTable {
   constructor () {

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const debug = require('debug')('five-bells-routing:routing-tables')
+const debug = require('debug')('ilp-routing:routing-tables')
 
 const PrefixMap = require('./prefix-map')
 const Route = require('./route')
@@ -46,6 +46,7 @@ class RoutingTables {
    */
   addRoute (_route) {
     const route = Route.fromData(_route)
+    debug('add route', route.connector, route.sourceLedger, route.sourceAccount)
     this.accounts[route.connector + ';' + route.sourceLedger] = route.sourceAccount
     if (route.destinationAccount) {
       this.accounts[route.connector + ';' + route.destinationLedger] = route.destinationAccount


### PR DESCRIPTION
This module is not specific to Five Bells Ledger, so it should be renamed to match our standard package naming scheme (`ilp-*`).