### PR TITLE
Feat: add removeLedger to remove ledger from routing tables

### DIFF
--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -37,6 +37,14 @@ class RoutingTables {
     localRoutes.forEach((route) => this.addRoute(route))
   }
 
+  removeLedger (ledger) {
+    this.eachRoute((routeFromAToB, ledgerA, ledgerB, nextHop) => {
+      if (ledgerA === ledger || ledgerB === ledger) {
+        this._removeRoute(ledgerA, ledgerB, nextHop)
+      }
+    })
+  }
+
   /**
    * Given a `route` B→C, create a route A→C for each source ledger A with a
    * local route to B.

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -261,6 +261,30 @@ describe('RoutingTables', function () {
     })
   })
 
+  describe('removeLedger', function () {
+    it('removes all of a ledger\'s routes', function () {
+      this.tables.addRoute({
+        source_ledger: ledgerB,
+        destination_ledger: ledgerC,
+        connector: 'http://mary.example',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      })
+
+      // remove the new route
+      assert.equal(this.tables.toJSON(10).length, 3)
+      this.tables.removeLedger(ledgerC)
+      assert.equal(this.tables.toJSON(10).length, 2)
+    })
+
+    it('removes no other ledger\'s routes', function () {
+      // remove nonexistant ledger
+      assert.equal(this.tables.toJSON(10).length, 2)
+      this.tables.removeLedger(ledgerC)
+      assert.equal(this.tables.toJSON(10).length, 2)
+    })
+  })
+
   describe('toJSON', function () {
     it('returns a list of routes', function () {
       this.tables.addRoute({


### PR DESCRIPTION
`removeAllRoutes` takes a ledger address, and removes all routes to and from it. Required by https://github.com/interledger/js-ilp-connector/pull/235