### PR TITLE
Fix: fix _removeRoute and removeLedger

### DIFF
--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -38,10 +38,14 @@ class RoutingTables {
   }
 
   removeLedger (ledger) {
+    const removeList = []
     this.eachRoute((routeFromAToB, ledgerA, ledgerB, nextHop) => {
       if (ledgerA === ledger || ledgerB === ledger) {
-        this._removeRoute(ledgerA, ledgerB, nextHop)
+        removeList.push({ ledgerA, ledgerB, nextHop })
       }
+    })
+    removeList.forEach((route) => {
+      this._removeRoute(route.ledgerA, route.ledgerB, route.nextHop)
     })
   }
 
@@ -93,6 +97,7 @@ class RoutingTables {
 
   _removeRoute (ledgerB, ledgerC, connectorFromBToC) {
     this.eachSource((tableFromA, ledgerA) => {
+      if (ledgerA !== ledgerB) return
       tableFromA.removeRoute(ledgerC, connectorFromBToC)
     })
   }

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -263,23 +263,49 @@ describe('RoutingTables', function () {
 
   describe('removeLedger', function () {
     it('removes all of a ledger\'s routes', function () {
-      this.tables.addRoute({
+      this.tables.addLocalRoutes([{
         source_ledger: ledgerB,
         destination_ledger: ledgerC,
         connector: 'http://mary.example',
         min_message_window: 1,
         points: [ [0, 0], [50, 60] ]
-      })
+      }, {
+        source_ledger: ledgerA,
+        destination_ledger: ledgerC,
+        connector: 'http://mary.example',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }, {
+        source_ledger: ledgerC,
+        destination_ledger: ledgerA,
+        connector: 'http://mary.example',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }, {
+        source_ledger: ledgerC,
+        destination_ledger: ledgerB,
+        connector: 'http://mary.example',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }])
 
       // remove the new route
-      assert.equal(this.tables.toJSON(10).length, 3)
+      assert.equal(this.tables.toJSON(10).length, 6)
       this.tables.removeLedger(ledgerC)
       assert.equal(this.tables.toJSON(10).length, 2)
     })
 
     it('removes no other ledger\'s routes', function () {
+      this.tables.addLocalRoutes([{
+        source_ledger: ledgerC,
+        destination_ledger: ledgerA,
+        connector: 'http://mary.example',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }])
+
       // remove nonexistant ledger
-      assert.equal(this.tables.toJSON(10).length, 2)
+      assert.equal(this.tables.toJSON(10).length, 3)
       this.tables.removeLedger(ledgerC)
       assert.equal(this.tables.toJSON(10).length, 2)
     })


### PR DESCRIPTION
`_removeRoute` had a bug which would cause it to remove several routes so long as they had the same destination and connector, ignoring the source ledger. `removeLedger` removed routes while iterating routes, causing it to skip items.